### PR TITLE
Resolve Kohese Tab not showing correctly when in the References and V…

### DIFF
--- a/kohese-portal/client/src/components/document-view/document-view.component.ts
+++ b/kohese-portal/client/src/components/document-view/document-view.component.ts
@@ -166,9 +166,7 @@ implements OnInit, OnDestroy {
 
     if (this.selectedProxyStream) {
       this.selectedProxySubscription = this.selectedProxyStream.subscribe((newSelection) => {
-        if (newSelection && (this.outlineView === false)) {
-          this.proxyTitle = newSelection.item.name;
-          this.title.setTitle('Explorer | ' + this.proxyTitle);
+        if (newSelection) {
           this.rowMap[newSelection.item.id].nativeElement.scrollIntoView();
         }
       });


### PR DESCRIPTION
…ersion Control Explorer tree tabs

Task: Resolve Kohese Tab not showing correctly when in the References and Version Control Explorer tree tabs (28cf28d0-de7f-11eb-a959-b3159f0ce200)
* Removed logic in document-view component that broke the ability to match focus in the tree and details pane for the document-tree and the document-view in outline mode
* Outline view now operates correctly