### PR TITLE
Fix Alignmnet of Explorer Tree Row

### DIFF
--- a/kohese-portal/client/src/components/tree/tree-row/tree-row.component.scss
+++ b/kohese-portal/client/src/components/tree/tree-row/tree-row.component.scss
@@ -82,7 +82,6 @@
 
 .kt-icon {
   cursor: pointer;
-  padding : 5px;
 }
 
 


### PR DESCRIPTION
Task: Fix alignment of Explorer Tree row (e7b96530-633b-11ec-99d8-394bd57acf24)
* tree-row icons should vertical-align symmetrically