### PR TITLE
Initialization State Changes

### DIFF
--- a/kohese-portal/client/src/components/admin/admin.component.html
+++ b/kohese-portal/client/src/components/admin/admin.component.html
@@ -16,7 +16,7 @@ limitations under the License.
 
 
 <div class=users-page-wrapper>
-  <ng-container *ngIf="sessionMap else initializing">
+  <ng-container *ngIf="initialized else initializing">
     <div class="panel-heading">Admin</div>
     <as-split unit=percent direction="horizontal">
 

--- a/kohese-portal/client/src/components/admin/admin.component.ts
+++ b/kohese-portal/client/src/components/admin/admin.component.ts
@@ -47,6 +47,7 @@ import { Hotkeys } from '../../services/hotkeys/hot-key.service';
 export class AdminComponent implements OnInit, OnDestroy {
   // Data
   private lockoutList: Array<string> = [];
+  initialized: boolean = false;
 
   // Getters
 
@@ -144,7 +145,7 @@ export class AdminComponent implements OnInit, OnDestroy {
 
     this.repositoryStatusSubscription = this._itemRepository.getRepoStatusSubject().subscribe(async (status: any) => {
       if (RepoStates.SYNCHRONIZATION_SUCCEEDED === status.state) {
-
+        this.initialized = true;
         let modelProxy : KoheseModel = TreeConfiguration.getWorkingTree().getModelProxyFor('KoheseUser');
         this._koheseUserDataModel = modelProxy.item;
         this._koheseUserViewModel = modelProxy.view.item;

--- a/kohese-portal/client/src/components/dashboard/dashboard.component.ts
+++ b/kohese-portal/client/src/components/dashboard/dashboard.component.ts
@@ -43,7 +43,7 @@ export class DashboardComponent extends NavigatableComponent implements OnInit, 
   assignmentListStream : BehaviorSubject<Array<ItemProxy>> = new BehaviorSubject<Array<ItemProxy>>([]);
 
   /**Dashboard Initializations */
-  opened: boolean = false;
+  opened: boolean = true;
   selectedDashboard : DashboardSelectionInfo = {
     dashboard : undefined,
     dashboardType : undefined


### PR DESCRIPTION
Task: Change initialization position of Dashboard and Users (Admin) page (90e4c680-a6e0-11ec-9109-f75a2b7db4d2)
* Change initial state of dashboard drawer from closed-> open 
* Remove dependence of progress spinner initialization from session map


note:
* This task may have additional work to base the session list initialization on something substantial other than repo status success