### PR TITLE
Repo will re-sync after socket.io reconnects

### DIFF
--- a/kohese-portal/server/koheseIO.ts
+++ b/kohese-portal/server/koheseIO.ts
@@ -40,7 +40,7 @@ function Server(httpsServer, options){
 
       socket.conn.on("upgrade", () => {
         const upgradedTransport = socket.conn.transport.name; // in most cases, "websocket"
-        console.log('>>>> upgraded transport to %s for session %s', upgradedTransport, socket.id);
+        console.log('>>> upgraded transport to %s for session %s', upgradedTransport, socket.id);
       });
 
       socket.on('authenticate', function(request) {

--- a/kohese-portal/server/tsconfig.json
+++ b/kohese-portal/server/tsconfig.json
@@ -13,8 +13,6 @@
     "noImplicitAny": false,
     "types": [
       "core-js",
-      "socket.io",
-      "socket.io-client",
       "node",
       "underscore",
       "jasmine",

--- a/kohese-portal/tsconfig.json
+++ b/kohese-portal/tsconfig.json
@@ -14,8 +14,6 @@
     "noImplicitAny": false,
     "types": [
       "core-js",
-      "socket.io",
-      "socket.io-client",
       "node",
       "underscore",
       "jasmine",


### PR DESCRIPTION
Task: Repo will re-sync after socket.io Reconnects (1de0ba40-d13d-11ec-b823-c5e0ddddae14)
* Repo will re-sync after socket.io-client 'reconnect' establishes a new connection