### PR TITLE
Optimize Bar Graph resizing

### DIFF
--- a/kohese-portal/client/src/components/dashboard/project-dashboard/status-dashboard/state-bar-chart/state-bar-chart.component.html
+++ b/kohese-portal/client/src/components/dashboard/project-dashboard/status-dashboard/state-bar-chart/state-bar-chart.component.html
@@ -85,7 +85,10 @@ limitations under the License.
     The padding-bottom value below is calculated via the following formula:
       padding-bottom = width * (viewBox height / viewBox width)
   -->
-  <svg class=svg-chart #chart viewBox="0 0 100 50" preserveAspectRatio="xMidYMin slice"></svg>
+  <svg  class=svg-chart #chart id="chart"
+        (window:resize)="onResize($event)"
+        viewBox="0 0 100 50"
+        preserveAspectRatio="xMidYMin slice"></svg>
   <ng-container *ngIf="selection">
     <div class=svg-chart-if-selection>
       <ng-container *ngIf="(selection.kindNames.length > 1)">

--- a/kohese-portal/client/src/components/dashboard/project-dashboard/status-dashboard/state-bar-chart/state-bar-chart.component.ts
+++ b/kohese-portal/client/src/components/dashboard/project-dashboard/status-dashboard/state-bar-chart/state-bar-chart.component.ts
@@ -243,6 +243,10 @@ export class StateBarChartComponent implements OnInit, AfterViewInit {
     }
   }
 
+  onResize() {
+    this.updateGraph();
+  }
+
   /**
    * sets the chart's x-axis labels and
    * determines the max number of items to be displayed for the y-axis


### PR DESCRIPTION
Task: Optimize Bar Graph resizing (0ef65810-0fc9-11ea-af3b-3581f6980f2c)
* When bar graph window is resized the graph will re-render to fit the window. 

Notes - 
Currently:
* Increasing magnification of bar graph causes part of bar graph to be out of visible range. 
* Resizing window does not automatically resize the chart. Must click on a column to get to resize. 
* Moving the Project Chart tab to the first tab causes the initial rendering of the chart to be unreadably small
* Open up the folding project pain causes the Column info popup on the right to cover the chart 
