### PR TITLE
Implement Create and Delete ops for state-summary

### DIFF
--- a/kohese-portal/client/src/components/dashboard/project-dashboard/status-dashboard/state-bar-chart/state-summary-dialog/state-summary-dialog.component.ts
+++ b/kohese-portal/client/src/components/dashboard/project-dashboard/status-dashboard/state-bar-chart/state-summary-dialog/state-summary-dialog.component.ts
@@ -153,22 +153,22 @@ export class StateSummaryDialogComponent implements OnInit, OnDestroy {
             this.changeRef.detectChanges();
           }
           break;
+        case 'create':
+          this.discernStateChanges(notification.proxy);
+          break;
         case 'update':
-          if(notification.proxy.state === this.stateName) {
-            if(!this.proxies.includes(notification.proxy)) {
-              this.proxies.push(notification.proxy);
-            }
-          } else {
-            if(this.proxies.includes(notification.proxy)) {
-              this.proxies.splice(this.proxies.indexOf(notification.proxy),1);
-            }
-          }
+          this.discernStateChanges(notification.proxy);
           this.changeRef.detectChanges();
           break;
         case 'delete':
+          this.discernStateChanges(notification.proxy);
+          if(this.proxies.includes(notification.proxy)) {
+            this.proxies.splice(this.proxies.indexOf(notification.proxy),1);
+          }
           if(this.numCommentsMap[notification.proxy.item.id]) {
             delete this.numCommentsMap[notification.proxy.item.id];
           }
+          this.changeRef.detectChanges();
           break;
       }
   });
@@ -180,6 +180,18 @@ export class StateSummaryDialogComponent implements OnInit, OnDestroy {
     }
     if(this._exitShortcutSubscription) {
       this._exitShortcutSubscription.unsubscribe();
+    }
+  }
+
+  discernStateChanges(proxy: ItemProxy) {
+    if(proxy.state === this.stateName) {
+      if(!this.proxies.includes(proxy)) {
+        this.proxies.push(proxy);
+      }
+    } else {
+      if(this.proxies.includes(proxy)) {
+        this.proxies.splice(this.proxies.indexOf(proxy),1);
+      }
     }
   }
 


### PR DESCRIPTION
Task: Implement create and delete operations for state-summary dialog (e63c28e0-f176-11ec-a4bd-f11717af68d9)
* Items updated, created or deleted elsewhere should reflect changes in the state  summary dialog